### PR TITLE
Fix ignored OpenOptions create flag

### DIFF
--- a/src/repo.rs
+++ b/src/repo.rs
@@ -629,7 +629,7 @@ impl Repo {
                     return Err(Error::AlreadyExists);
                 }
             }
-            Err(ref err) if *err == Error::NotFound => {
+            Err(ref err) if *err == Error::NotFound && opts.create => {
                 self.fs
                     .create_fnode(path, FileType::File, opts.version_limit)?;
             }

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -304,6 +304,26 @@ fn file_read_write() {
         f.write_once(&buf[..]).unwrap();
         verify_content(&mut f, &buf[..]);
     }
+
+    // #15, test create open flag
+    {
+        assert!(!repo.is_file("/file15"));
+        assert_eq!(
+            OpenOptions::new()
+                .create(false)
+                .open(&mut repo, "/file15")
+                .unwrap_err(),
+            Error::NotFound
+        );
+        OpenOptions::new()
+            .create(true)
+            .open(&mut repo, "/file15")
+            .unwrap();
+        OpenOptions::new()
+            .create(false)
+            .open(&mut repo, "/file9")
+            .unwrap();
+    }
 }
 
 #[test]


### PR DESCRIPTION
Hi there !

While working on Python bindings for `zbox`, I realized that the `create` flag of `OpenOptions` was not being used, as a new file was created unconditionally. 

I just made sure the `NotFound` error is only discarded when `create` is set to `true`, and added a small test case as well. This is not a very large PR, but don't hesitate if anything needs to be changed !