### PR TITLE
Fix wrong position returned by `File.seek`

### DIFF
--- a/tests/file.rs
+++ b/tests/file.rs
@@ -582,22 +582,26 @@ fn file_seek() {
 
         // seek from start
         let mut dst = Vec::new();
-        f.seek(SeekFrom::Start(2)).unwrap();
+        let pos = f.seek(SeekFrom::Start(2)).unwrap();
+        assert_eq!(pos, 2);
         let result = f.read_to_end(&mut dst).unwrap();
         assert_eq!(result, buf.len() - 2);
         assert_eq!(&dst[..], &buf[2..]);
 
         // seek from end
         let mut dst = Vec::new();
-        f.seek(SeekFrom::End(-2)).unwrap();
+        let pos = f.seek(SeekFrom::End(-2)).unwrap();
+        assert_eq!(pos, 1);
         let result = f.read_to_end(&mut dst).unwrap();
         assert_eq!(result, buf.len() - 1);
         assert_eq!(&dst[..], &buf[1..]);
 
         // seek from current
         let mut dst = Vec::new();
-        f.seek(SeekFrom::Start(1)).unwrap();
-        f.seek(SeekFrom::Current(1)).unwrap();
+        let pos = f.seek(SeekFrom::Start(1)).unwrap();
+        assert_eq!(pos, 1);
+        let pos = f.seek(SeekFrom::Current(1)).unwrap();
+        assert_eq!(pos, 2);
         let result = f.read_to_end(&mut dst).unwrap();
         assert_eq!(result, buf.len() - 2);
         assert_eq!(&dst[..], &buf[2..]);


### PR DESCRIPTION
Hi there,

`File.seek` is expected to return the new position from the start of the file, but didn't, instead returning zero when for instance no reader was initialized. I fixed it by returning the result of `seek_pos` in such cases. I added a few assertions to the existing seeking test case as well.