### PR TITLE
bundle libsodium with feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ storage-zbox-wasm = ["storage-zbox", "wasm-bindgen", "js-sys", "web-sys", "wee_a
 # zbox storage base dependencies
 storage-zbox = ["http", "serde_json"]
 
+libsodium-bundled = []
+
 [dependencies]
 bytes = "0.4.10"
 cfg-if = "0.1.6"
@@ -102,4 +104,9 @@ rand = "0.6.5"
 rand_xorshift = "0.1.1"
 
 [build-dependencies]
+libflate = "0.1"
 pkg-config = "0.3.14"
+reqwest = "0.9"
+tar = "0.4"
+tempfile = "3.0"
+zip = "0.5"

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,19 @@
+extern crate libflate;
 extern crate pkg_config;
+extern crate reqwest;
+extern crate tar;
 
 use std::env;
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=SODIUM_LIB_DIR");
-    println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
+    #[cfg(feature = "libsodium-bundled")]
+    download_and_install_libsodium();
+
+    #[cfg(not(feature = "libsodium-bundled"))]
+    {
+        println!("cargo:rerun-if-env-changed=SODIUM_LIB_DIR");
+        println!("cargo:rerun-if-env-changed=SODIUM_STATIC");
+    }
 
     // add libsodium link options
     if let Ok(lib_dir) = env::var("SODIUM_LIB_DIR") {
@@ -28,4 +37,184 @@ fn main() {
             .probe("libsodium")
             .unwrap();
     }
+}
+
+// This downloads function and builds the libsodium from source for linux and unix targets.
+// The steps are taken from the libsodium installation instructions:
+// https://libsodium.gitbook.io/doc/installation
+// effectively:
+// $ ./configure
+// $ make && make check
+// $ sudo make install
+#[cfg(all(feature = "libsodium-bundled", not(target_os = "windows")))]
+fn download_and_install_libsodium() {
+    use libflate::non_blocking::gzip::Decoder;
+    use std::io::{stderr, stdout, Write};
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use tar::Archive;
+    static LIBSODIUM_ZIP: &'static str = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.17.tar.gz";
+    static LIBSODIUM_NAME: &'static str = "libsodium-1.0.17";
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let install_dir = out_dir.join("libsodium_install");
+    let source_dir = install_dir.join(LIBSODIUM_NAME);
+    let prefix_dir = out_dir.join("libsodium");
+    let sodium_lib_dir = prefix_dir.join("lib");
+
+    if !install_dir.exists() {
+        let response = reqwest::get(LIBSODIUM_ZIP).unwrap();
+        let decoder = Decoder::new(response);
+        let mut ar = Archive::new(decoder);
+        ar.unpack(&install_dir).unwrap();
+    }
+
+    if !sodium_lib_dir.exists() {
+        let configure = source_dir.join("./configure");
+        let output = Command::new(&configure)
+            .current_dir(&source_dir)
+            .args(&[Path::new("--prefix"), &prefix_dir])
+            .output()
+            .expect("failed to execute configure");
+        stdout().write_all(&output.stdout).unwrap();
+        stderr().write_all(&output.stderr).unwrap();
+
+        let output = Command::new("make")
+            .current_dir(&source_dir)
+            .output()
+            .expect("failed to execute make");
+        stdout().write_all(&output.stdout).unwrap();
+        stderr().write_all(&output.stderr).unwrap();
+
+        let output = Command::new("make")
+            .current_dir(&source_dir)
+            .arg("check")
+            .output()
+            .expect("failed to execute make check");
+        stdout().write_all(&output.stdout).unwrap();
+        stderr().write_all(&output.stderr).unwrap();
+
+        let output = std::process::Command::new("make")
+            .current_dir(&source_dir)
+            .arg("install")
+            .output()
+            .expect("failed to execute sudo make install");
+        stdout().write_all(&output.stdout).unwrap();
+        stderr().write_all(&output.stderr).unwrap();
+    }
+
+    assert!(
+        &sodium_lib_dir.exists(),
+        "libsodium lib directory was not created."
+    );
+
+    env::set_var("SODIUM_LIB_DIR", &sodium_lib_dir);
+    env::set_var("SODIUM_STATIC", "true");
+}
+
+// This downloads function and builds the libsodium from source for windows msvc target.
+// The binaries are pre-compiled, so we simply download and link.
+// The binary is compressed in zip format.
+#[cfg(all(
+    feature = "libsodium-bundled",
+    target_os = "windows",
+    target_env = "msvc"
+))]
+fn download_and_install_libsodium() {
+    use std::fs;
+    use std::fs::OpenOptions;
+    use std::io;
+    use std::path::PathBuf;
+    #[cfg(target_env = "msvc")]
+    static LIBSODIUM_ZIP: &'static str = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-msvc.zip";
+    #[cfg(target_env = "mingw")]
+    static LIBSODIUM_ZIP: &'static str = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-mingw.tar.gz";
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let sodium_lib_dir = out_dir.join("libsodium");
+    if !sodium_lib_dir.exists() {
+        fs::create_dir(&sodium_lib_dir).unwrap();
+    }
+    let sodium_lib_file_path = sodium_lib_dir.join("libsodium.lib");
+    if !sodium_lib_file_path.exists() {
+        let mut tmpfile = tempfile::tempfile().unwrap();
+        reqwest::get(LIBSODIUM_ZIP)
+            .unwrap()
+            .copy_to(&mut tmpfile)
+            .unwrap();
+        let mut zip = zip::ZipArchive::new(tmpfile).unwrap();
+        #[cfg(target_arch = "x86_64")]
+        let mut lib = zip
+            .by_name("x64/Release/v142/static/libsodium.lib")
+            .unwrap();
+        #[cfg(target_arch = "x86")]
+        let mut lib = zip
+            .by_name("Win32/Release/v142/static/libsodium.lib")
+            .unwrap();
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+        compile_error!("Bundled libsodium is only supported on x86 or x86_64 target architecture.");
+        let mut libsodium_file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&sodium_lib_file_path)
+            .unwrap();
+        io::copy(&mut lib, &mut libsodium_file).unwrap();
+    }
+    assert!(
+        &sodium_lib_dir.exists(),
+        "libsodium lib directory was not created."
+    );
+    env::set_var("SODIUM_LIB_DIR", &sodium_lib_dir);
+    env::set_var("SODIUM_STATIC", "true");
+}
+
+// This downloads function and builds the libsodium from source for windows mingw target.
+// The binaries are pre-compiled, so we simply download and link.
+// The binary is compressed in tar.gz format.
+#[cfg(all(
+    feature = "libsodium-bundled",
+    target_os = "windows",
+    target_env = "gnu"
+))]
+fn download_and_install_libsodium() {
+    use libflate::non_blocking::gzip::Decoder;
+    use std::fs;
+    use std::fs::OpenOptions;
+    use std::io;
+    use std::path::PathBuf;
+    use tar::Archive;
+    static LIBSODIUM_ZIP: &'static str = "https://download.libsodium.org/libsodium/releases/libsodium-1.0.17-mingw.tar.gz";
+    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let sodium_lib_dir = out_dir.join("libsodium");
+    if !sodium_lib_dir.exists() {
+        fs::create_dir(&sodium_lib_dir).unwrap();
+    }
+    let sodium_lib_file_path = sodium_lib_dir.join("libsodium.lib");
+    if !sodium_lib_file_path.exists() {
+        let response = reqwest::get(LIBSODIUM_ZIP).unwrap();
+        let decoder = Decoder::new(response);
+        let mut ar = Archive::new(decoder);
+        #[cfg(target_arch = "x86_64")]
+        let filename = PathBuf::from("libsodium-win64/lib/libsodium.a");
+        #[cfg(target_arch = "x86")]
+        let filename = PathBuf::from("libsodium-win32/lib/libsodium.a");
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+        compile_error!("Bundled libsodium is only supported on x86 or x86_64 target architecture.");
+        for file in ar.entries().unwrap() {
+            let mut f = file.unwrap();
+            if f.path().unwrap() == *filename {
+                let mut libsodium_file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .open(&sodium_lib_file_path)
+                    .unwrap();
+                io::copy(&mut f, &mut libsodium_file).unwrap();
+                break;
+            }
+        }
+    }
+    assert!(
+        &sodium_lib_dir.exists(),
+        "libsodium lib directory was not created."
+    );
+    env::set_var("SODIUM_LIB_DIR", &sodium_lib_dir);
+    env::set_var("SODIUM_STATIC", "true");
 }


### PR DESCRIPTION
This PR adds a solution for issue #34. The build script is updated to download, build, and link libsodium statically. On unix, the sources are downloaded, built, and linked statically. On windows, for mingw and msvc, the pre-compiled binaries are downloaded and linked statically. The bundled build is toggled with a feature flag: `libsodium-bundled`.

I reviewed the contributing guide and tried my best to run the required tests. I made a few changes to test with the new bundled libsodium. I ran the different test commands on my windows box for both mingw and msvc targets. I also ran them on my linux subsystem which is ubuntu (I think?). 

`cargo test --lib --features libsodium-bundled`
`cargo test --tests --features libsodium-bundled`
`cargo test --doc --features libsodium-bundled`
`cargo test --tests fuzz_test --features libsodium-bundled -- --nocapture`
`cargo test --tests perf_test --release --features test-perf,libsodium-bundled -- --nocapture`

I noticed that `fuzz_test` with `storage-faulty` did not compile for any of the targets with or without the new bundled libsodium. I am happy to submit a bug if that would help 😄 
`cargo test --tests fuzz_test --features storage-faulty -- --nocapture`

I am happy to make changes, especially if they help with readability. I also would be happy to add a test in travis if that would increase confidence.