### PR TITLE
Use rustls-tls in reqwest dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ libsqlite3-sys = { version = "0.15.0", optional = true }
 redis = { version = "0.10.0", optional = true }
 http  = { version = "0.1.17", optional = true }
 serde_json = { version = "1.0.39", optional = true }
-reqwest  = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ], optional = true }
+reqwest = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ], optional = true }
 
 [dependencies.linked-hash-map]
 version = "0.5.1"
@@ -97,7 +97,7 @@ pkg-config = "0.3.14"
 [target.'cfg(target_os = "windows")'.build-dependencies]
 libflate = "0.1"
 pkg-config = "0.3.14"
-reqwest = "0.9"
+reqwest = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ], optional = true }
 tar = "0.4"
 tempfile = "3.0"
 zip = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ pkg-config = "0.3.14"
 [target.'cfg(target_os = "windows")'.build-dependencies]
 libflate = "0.1"
 pkg-config = "0.3.14"
-reqwest = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ], optional = true }
+reqwest = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ] }
 tar = "0.4"
 tempfile = "3.0"
 zip = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ libsqlite3-sys = { version = "0.15.0", optional = true }
 redis = { version = "0.10.0", optional = true }
 http  = { version = "0.1.17", optional = true }
 serde_json = { version = "1.0.39", optional = true }
-reqwest  = { version = "0.9.5", optional = true }
+reqwest  = { version = "0.9.18", default-features = false, features = [ "rustls-tls" ], optional = true }
 
 [dependencies.linked-hash-map]
 version = "0.5.1"


### PR DESCRIPTION
Use `rustls-tls` feature in `reqwest` to remove external dependency on OpenSSL and replace it with [rustls](https://github.com/ctz/rustls), a native Rust TLS implementation.

This allows `zbox` to be used in environments where OpenSSL is not present or desirable.