### PR TITLE
Fixed windows msvc download_and_install_libsodium in build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ cc = "1.0.70"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 libflate = "1.1.1"
-reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.11.4", default-features = false, features = ["rustls-tls", "blocking"] }
 tar = "0.4.37"
 tempfile = "3.2.0"
 zip = "0.5.13"

--- a/build.rs
+++ b/build.rs
@@ -214,18 +214,18 @@ fn download_and_install_libsodium() {
     let sodium_lib_file_path = sodium_lib_dir.join("libsodium.lib");
     if !sodium_lib_file_path.exists() {
         let mut tmpfile = tempfile::tempfile().unwrap();
-        reqwest::get(LIBSODIUM_ZIP)
+        reqwest::blocking::get(LIBSODIUM_ZIP)
             .unwrap()
             .copy_to(&mut tmpfile)
             .unwrap();
         let mut zip = zip::ZipArchive::new(tmpfile).unwrap();
         #[cfg(target_arch = "x86_64")]
         let mut lib = zip
-            .by_name("x64/Release/v142/static/libsodium.lib")
+            .by_name("libsodium/x64/Release/v142/static/libsodium.lib")
             .unwrap();
         #[cfg(target_arch = "x86")]
         let mut lib = zip
-            .by_name("Win32/Release/v142/static/libsodium.lib")
+            .by_name("libsodium/Win32/Release/v142/static/libsodium.lib")
             .unwrap();
         #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
         compile_error!("Bundled libsodium is only supported on x86 or x86_64 target architecture.");


### PR DESCRIPTION
I was recently working on a project using zboz, from windows with msvc.

I noticed that whenever I add the "libsodium-bundled" feature, cargo throws a File Not Found error, more precisely it cannot find libsodium.lib in the temporary ZIP archive. I checked and indeed the path is wrong. Currently I understand it to be:
- libsodium/x64/Release/v142/static/libsodium.lib
- libsodium/Win32/Release/v142/static/libsodium.lib

Also after changing the paths, cargo throws another error but this time from reqwest: "reqwest::get" is asynchronous. I added the "blocking" feature in Cargo.toml only in the windows target and changed the code to "reqwest::blocking::get"